### PR TITLE
Fix flaky test

### DIFF
--- a/src/test/java/com/amazon/dtasdk/v2/serialization/messages/InstantAccessRequestTest.java
+++ b/src/test/java/com/amazon/dtasdk/v2/serialization/messages/InstantAccessRequestTest.java
@@ -19,6 +19,8 @@ import com.amazon.dtasdk.serializer.JacksonSerializer;
 import com.amazon.dtasdk.serializer.SerializationException;
 import org.junit.Test;
 
+import java.util.HashMap;
+
 import static org.junit.Assert.assertEquals;
 
 @Deprecated
@@ -33,9 +35,20 @@ public class InstantAccessRequestTest {
         request.setInfoField2("AMZN");
 
         String requestString = serializer.encode(request);
+        requestString = requestString.replace("{","").replace("}","").replace("\"","");
+        HashMap<String, String> payloadMap = new HashMap<String, String>();
+        String[] pairs = requestString.split(",");
+        for (int i=0; i<pairs.length; i++) {
+                String pair = pairs[i];
+                String[] keyValue = pair.split(":");
+                payloadMap.put(keyValue[0], keyValue[1]);
+        }
+        HashMap<String, String> expected = new HashMap<String, String>();
+        expected.put("operation", "GetUserId");
+        expected.put("infoField1", "nobody@amazon.com");
+        expected.put("infoField2", "AMZN");
 
-        assertEquals("{\"operation\":\"GetUserId\",\"infoField1\":\"nobody@amazon.com\",\"infoField2\":\"AMZN\"}",
-                requestString);
+        assertEquals(payloadMap, expected);
     }
 
     @Test

--- a/src/test/java/com/amazon/dtasdk/v2/serialization/messages/InstantAccessRequestTest.java
+++ b/src/test/java/com/amazon/dtasdk/v2/serialization/messages/InstantAccessRequestTest.java
@@ -36,19 +36,19 @@ public class InstantAccessRequestTest {
 
         String requestString = serializer.encode(request);
         requestString = requestString.replace("{","").replace("}","").replace("\"","");
-        HashMap<String, String> payloadMap = new HashMap<String, String>();
+        HashMap<String, String> requestMap = new HashMap<String, String>();
         String[] pairs = requestString.split(",");
         for (int i=0; i<pairs.length; i++) {
                 String pair = pairs[i];
                 String[] keyValue = pair.split(":");
-                payloadMap.put(keyValue[0], keyValue[1]);
+                requestMap.put(keyValue[0], keyValue[1]);
         }
         HashMap<String, String> expected = new HashMap<String, String>();
         expected.put("operation", "GetUserId");
         expected.put("infoField1", "nobody@amazon.com");
         expected.put("infoField2", "AMZN");
 
-        assertEquals(payloadMap, expected);
+        assertEquals(requestMap, expected);
     }
 
     @Test

--- a/src/test/java/com/amazon/dtasdk/v3/messages/InstantAccessRequestTest.java
+++ b/src/test/java/com/amazon/dtasdk/v3/messages/InstantAccessRequestTest.java
@@ -36,19 +36,19 @@ public class InstantAccessRequestTest {
 
         String requestString = serializer.encode(request);
         requestString = requestString.replace("{","").replace("}","").replace("\"","");
-        HashMap<String, String> payloadMap = new HashMap<String, String>();
+        HashMap<String, String> requestMap = new HashMap<String, String>();
         String[] pairs = requestString.split(",");
         for (int i=0; i<pairs.length; i++) {
                 String pair = pairs[i];
                 String[] keyValue = pair.split(":");
-                payloadMap.put(keyValue[0], keyValue[1]);
+                requestMap.put(keyValue[0], keyValue[1]);
         }
         HashMap<String, String> expected = new HashMap<String, String>();
         expected.put("operation", "GetUserId");
         expected.put("infoField1", "nobody@amazon.com");
         expected.put("infoField2", "AMZN");
 
-        assertEquals(payloadMap, expected);
+        assertEquals(requestMap, expected);
     }
 
     @Test

--- a/src/test/java/com/amazon/dtasdk/v3/messages/InstantAccessRequestTest.java
+++ b/src/test/java/com/amazon/dtasdk/v3/messages/InstantAccessRequestTest.java
@@ -20,6 +20,8 @@ import com.amazon.dtasdk.v3.serialization.messages.GetUserIdSerializableRequest;
 import com.amazon.dtasdk.base.InstantAccessOperationValue;
 import org.junit.Test;
 
+import java.util.HashMap;
+
 import static org.junit.Assert.assertEquals;
 
 public class InstantAccessRequestTest {
@@ -33,9 +35,20 @@ public class InstantAccessRequestTest {
         request.setInfoField2("AMZN");
 
         String requestString = serializer.encode(request);
+        requestString = requestString.replace("{","").replace("}","").replace("\"","");
+        HashMap<String, String> payloadMap = new HashMap<String, String>();
+        String[] pairs = requestString.split(",");
+        for (int i=0; i<pairs.length; i++) {
+                String pair = pairs[i];
+                String[] keyValue = pair.split(":");
+                payloadMap.put(keyValue[0], keyValue[1]);
+        }
+        HashMap<String, String> expected = new HashMap<String, String>();
+        expected.put("operation", "GetUserId");
+        expected.put("infoField1", "nobody@amazon.com");
+        expected.put("infoField2", "AMZN");
 
-        assertEquals("{\"operation\":\"GetUserId\",\"infoField1\":\"nobody@amazon.com\",\"infoField2\":\"AMZN\"}",
-                requestString);
+        assertEquals(payloadMap, expected);
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
The `testSerialize` compares the serialization String directly, and the order of fields is non-deterministic, which causes it to be a flaky test. 

*Description of changes:*
I fixed this issue by converting the String into a hashmap and compare, to avoid order issue. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
